### PR TITLE
[PR] Added multi-screen support

### DIFF
--- a/electron.d.ts
+++ b/electron.d.ts
@@ -1,0 +1,20 @@
+declare namespace electron {
+    interface Bounds {
+        x: number,
+        y: number,
+        width: number,
+        height: number
+    }
+
+    const remote: {
+        getCurrentWindow(): {
+            getBounds(): Bounds
+        }
+
+        screen: {
+            getDisplayMatching(bounds: Bounds): {
+                bounds: Bounds
+            }
+        }
+    }
+}

--- a/electron.d.ts
+++ b/electron.d.ts
@@ -9,6 +9,8 @@ declare namespace electron {
     const remote: {
         getCurrentWindow(): {
             getBounds(): Bounds
+
+            isFullScreen(): boolean
         }
 
         screen: {

--- a/main.ts
+++ b/main.ts
@@ -211,7 +211,7 @@ export default class PseudoMica extends Plugin {
         document.body.style.setProperty("--pseudo-mica-screen-width", `${screenWidth}px`);
         document.body.style.setProperty("--pseudo-mica-screen-height", `${screenHeight}px`);
       }
-      this.frameRequest = requestAnimationFrame(updatePosition);
+      this.frameRequest = requestAnimationFrame(updateSize);
     }
 
     const handleResize = () => {

--- a/main.ts
+++ b/main.ts
@@ -191,11 +191,17 @@ export default class PseudoMica extends Plugin {
 
     // Removed 'styles' parameter
     const updatePosition = () => {
-      const { screenX, screenY } = window;
+      let { screenX, screenY } = window;
       if (this.lastPosition.x !== screenX || this.lastPosition.y !== screenY) {
-
-        const displayPositions = getCurrentDisplayPositions()
+        
+        const displayPositions = getCurrentDisplayPositions();
         Object.assign(this.lastPosition, { x: screenX, y: screenY });
+        
+        const isFullScreen = electron.remote.getCurrentWindow().isFullScreen();
+        if (isFullScreen) {
+          screenX = 0;
+          screenY = 0;
+        }
         // Update CSS variables directly on the body's style
         document.body.style.setProperty("--pseudo-mica-translate-x", `${-screenX+displayPositions.x}px`);
         document.body.style.setProperty("--pseudo-mica-translate-y", `${-screenY+displayPositions.y}px`);

--- a/main.ts
+++ b/main.ts
@@ -150,7 +150,7 @@ export default class PseudoMica extends Plugin {
                   body {
                       --titlebar-background-focused: transparent;
                   }
-                  body::before {
+                  .app-container::before {
                       width: var(--pseudo-mica-screen-width);
                       height: var(--pseudo-mica-screen-height);
                       background-image: url(data:image/jpeg;base64,${base64Image});

--- a/main.ts
+++ b/main.ts
@@ -167,6 +167,7 @@ export default class PseudoMica extends Plugin {
                       
                   .is-translucent:not(.is-fullscreen) .titlebar {
                       background-color: transparent;
+                      --titlebar-background: transparent;
                   }`;
 
         document.head.appendChild(this.styleEl);

--- a/main.ts
+++ b/main.ts
@@ -240,6 +240,8 @@ export default class PseudoMica extends Plugin {
       document.body.style.removeProperty("--pseudo-mica-translate-y");
       document.body.style.removeProperty("--pseudo-mica-screen-width");
       document.body.style.removeProperty("--pseudo-mica-screen-height");
+
+      document.body.classList.remove("is-translucent");
     });
   }
 


### PR DESCRIPTION
# Added multi-screen support

Hello, based on response in issue #2 I decided to implement this feature. This pull request develops/fixes following:

- Add multi screen support - if obsidian window goes on another window, It will re-calculate the background position relatively to monitor, it respects size of monitor as well
- Fix: When plugin was disabled, the `is-translucent` class was kept on body, this PR removes it on unloading
- Fix: Removed background for titlebar buttons if window is unfocused
- Fix: Fixed position shifting inappropriately of background for fullscreen mode (I know that plugin hides background if app is in fullscreen, but I use this in fullscreen as well, showing via snippets, this does not harm function of the plugin in any way)

Here is a showcase video of this pull-request. I have two different sized monitors (main connected and laptop one) to test the scale.

https://github.com/user-attachments/assets/c7f61175-68db-4561-822f-c66cc83eaba0

Only thing that is little bit off is the black part when you move window to another monitor (or you release window mid-of moving) but this would require further implementation with multiple canvases and adjacent monitor martix calculating. This is something I do not have time for, sorry about that.

I tried to write code according to your conventions and codebase. I added file for typing electron to satisfy es-lint (I used electron to get monitor dimensions).

If anything seems to be wrong, feel free to request changes or change them on your own.

Thank you for developing this plugin, makes my obsidian look really fancy ❤️ 