### PR TITLE
Fix: ensure PowerShell outputs UTF-8 for the wallpaper path

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -219,7 +219,7 @@ export default class PseudoMica extends Plugin {
   private async getWallpaperPath(): Promise<string> {
     if (!Platform.isWin) return "";
     try {
-      const { stdout } = await this.exec(`powershell -command "(Get-ItemProperty -Path 'HKCU:\\Control Panel\\Desktop' -Name Wallpaper).Wallpaper"`);
+      const { stdout } = await this.exec(`powershell -noprofile -command "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; (Get-ItemProperty -Path 'HKCU:\\Control Panel\\Desktop' -Name Wallpaper).Wallpaper"`);
       return stdout.trim();
     } catch {
       return "";


### PR DESCRIPTION
This PR fixes an issue where wallpaper file paths containing non-ASCII characters (e.g. "á", "ñ", "你") are garbled when retrieved by the plugin by ensuring PowerShell emits UTF-8 for the output. This allows users with non-English locales to use the plugin without having to move their wallpaper to a path without Unicode characters.

I also found out that, without `-noprofile`, profile scripts might inject additional output into stdout, in which case it would also break the plugin, so I added that as well.

Thanks for this amazing plugin. Hope this helps!